### PR TITLE
fix cmd\creator.go:33:23: cannot use syscall.Stdin (variable of type …

### DIFF
--- a/cmd/creator.go
+++ b/cmd/creator.go
@@ -30,7 +30,7 @@ var creatorCmd = &cobra.Command{
 	Short: "Use the interactive dockware creator to get what you need for today's task",
 	Long:  "",
 	Run: func(cmd *cobra.Command, args []string) {
-		if !term.IsTerminal(syscall.Stdin) {
+		if !term.IsTerminal(int(syscall.Stdin)) {
 			log.Fatal("interactive terminal required")
 		}
 


### PR DESCRIPTION
Fix the bug: cmd\creator.go:33:23: cannot use syscall.Stdin (variable of type syscall.Handle) as int value in argument to term.IsTerminal (on windows amd64).

For info: The file https://dockware.io/download/cli/windows/arm/dockware-cli is missing on the page https://dockware.io/cli.